### PR TITLE
v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![NPM Version](http://img.shields.io/npm/v/altnode.static-stereo-panner-node.svg?style=flat-square)](https://www.npmjs.org/package/altnode.static-stereo-panner-node)
 [![License](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](http://mohayonao.mit-license.org/)
 
+![graph](https://github.com/altnode/static-stereo-panner-node/wiki/images/static-stereo-panner-node.png)
+
 ## Installation
 
 ```
@@ -10,7 +12,7 @@ npm install -S altnode.static-stereo-panner-node
 ```
 
 ## API
-### AudioNode
+### StaticStereoPannerNode
 - `constructor(audioContext: AudioContext)`
 
 #### Instance attributes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "altnode.static-stereo-panner-node",
   "description": "altnode.StaticStereoPannerNode",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Nao Yonamine <mohayonao@gmail.com>",
   "bugs": {
     "url": "https://github.com/altnode/static-stereo-panner-node/issues"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/altnode/static-stereo-panner-node/issues"
   },
   "dependencies": {
-    "altnode.audio-node": "^0.1.1"
+    "altnode.alt-audio-node": "^0.2.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/src/StaticStereoPannerNode.js
+++ b/src/StaticStereoPannerNode.js
@@ -1,8 +1,8 @@
-import AudioNode from "altnode.audio-node";
+import AltAudioNode from "altnode.alt-audio-node";
 import StaticParam from "./StaticParam";
 import { PAN, SPLITTER, GAIN_L, GAIN_R, MERGER } from "./symbols";
 
-export default class StaticStereoPannerNode extends AudioNode {
+export default class StaticStereoPannerNode extends AltAudioNode {
   constructor(audioContext) {
     super(audioContext);
 


### PR DESCRIPTION
- use `altnode.AltAudioNode` instead of `altnode.AudioNode`
